### PR TITLE
Set MIX_ENV during Phoenix digest

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :bootleg_phoenix, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:bootleg_phoenix, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :logger,
+  level: :warn

--- a/lib/bootleg/tasks/phoenix_digest.ex
+++ b/lib/bootleg/tasks/phoenix_digest.ex
@@ -1,13 +1,15 @@
 defmodule Bootleg.Tasks.PhoenixDigest do
-  @moduledoc "Installs needed depedencies and calls `mix phoenix.digest`."
-  alias Bootleg.UI
+  @moduledoc "Installs dependencies and calls `mix phoenix.digest`."
+
+  alias Bootleg.{Config, UI}
 
   use Bootleg.Task do
     task :phoenix_digest do
+      mix_env = Config.get_config(:mix_env, "prod")
       remote :build do
-        "[ -f package.json ] && npm install || true"
-        "[ -f brunch-config.js ] && [ -d node_modules ] && ./node_modules/brunch/bin/brunch b -p || true"
-        "[ -d deps/phoenix ] && mix phoenix.digest || true"
+        "npm install"
+        "./node_modules/brunch/bin/brunch build --production"
+        "MIX_ENV=#{mix_env} mix phoenix.digest"
       end
       UI.info "Phoenix asset digest generated"
     end

--- a/test/fixtures/drunkin_phoenix/brunch-config.js
+++ b/test/fixtures/drunkin_phoenix/brunch-config.js
@@ -1,0 +1,69 @@
+exports.config = {
+  // See http://brunch.io/#documentation for docs.
+  files: {
+    javascripts: {
+      joinTo: "js/app.js"
+
+      // To use a separate vendor.js bundle, specify two files path
+      // http://brunch.io/docs/config#-files-
+      // joinTo: {
+      //  "js/app.js": /^(web\/static\/js)/,
+      //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/
+      // }
+      //
+      // To change the order of concatenation of files, explicitly mention here
+      // order: {
+      //   before: [
+      //     "web/static/vendor/js/jquery-2.1.1.js",
+      //     "web/static/vendor/js/bootstrap.min.js"
+      //   ]
+      // }
+    },
+    stylesheets: {
+      joinTo: "css/app.css",
+      order: {
+        after: ["web/static/css/app.css"] // concat app.css last
+      }
+    },
+    templates: {
+      joinTo: "js/app.js"
+    }
+  },
+
+  conventions: {
+    // This option sets where we should place non-css and non-js assets in.
+    // By default, we set this to "/web/static/assets". Files in this directory
+    // will be copied to `paths.public`, which is "priv/static" by default.
+    assets: /^(web\/static\/assets)/
+  },
+
+  // Phoenix paths configuration
+  paths: {
+    // Dependencies and current project directories to watch
+    watched: [
+      "web/static",
+      "test/static"
+    ],
+
+    // Where to compile files to
+    public: "priv/static"
+  },
+
+  // Configure your plugins
+  plugins: {
+    babel: {
+      // Do not use ES6 compiler in vendor code
+      ignore: [/web\/static\/vendor/]
+    }
+  },
+
+  modules: {
+    autoRequire: {
+      "js/app.js": ["web/static/js/app"]
+    }
+  },
+
+  npm: {
+    enabled: true
+  }
+};

--- a/test/fixtures/drunkin_phoenix/mix.exs
+++ b/test/fixtures/drunkin_phoenix/mix.exs
@@ -33,6 +33,7 @@ defmodule DrunkinPhoenix.Mixfile do
       {:phoenix_pubsub, "~> 1.0"},
       {:cowboy, "~> 1.0"},
       {:distillery, "~> 1.4", runtime: false},
+      {:bootleg, "~> 0.2.0", runtime: false, override: true},
       {:bootleg_phoenix, ">= 0.0.0", path: System.get_env("BOOTLEG_PHOENIX_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/drunkin_phoenix/package.json
+++ b/test/fixtures/drunkin_phoenix/package.json
@@ -1,0 +1,19 @@
+{
+  "repository": {},
+  "license": "MIT",
+  "scripts": {
+    "deploy": "brunch build --production",
+    "watch": "brunch watch --stdin"
+  },
+  "dependencies": {
+    "phoenix": "file:deps/phoenix"
+  },
+  "devDependencies": {
+    "babel-brunch": "~6.0.0",
+    "brunch": "2.7.4",
+    "clean-css-brunch": "~2.0.0",
+    "css-brunch": "~2.0.0",
+    "javascript-brunch": "~2.0.0",
+    "uglify-js-brunch": "~2.0.1"
+  }
+}

--- a/test/phoenix_digest_test.exs
+++ b/test/phoenix_digest_test.exs
@@ -3,10 +3,12 @@ defmodule BootlegPhoenix.PhoenixDigestTest do
   use BootlegPhoenix.FunctionalCase
 
   setup do
-    %{app_location: Fixtures.inflate_project(:drunkin_phoenix)}
+    %{
+      app_location: Fixtures.inflate_project(:drunkin_phoenix)
+    }
   end
 
-  @tag boot: 2, timeout: 120_000
+  @tag boot: 2, timeout: 360_000
   test "phoenix_digest generates the digest during compile", %{app_location: location, hosts: hosts} do
     shell_env = [
       {"BOOTLEG_PHOENIX_PATH", File.cwd!},
@@ -14,6 +16,11 @@ defmodule BootlegPhoenix.PhoenixDigestTest do
     ]
     build_host = List.first(hosts)
     app_hosts = hosts -- [build_host]
+    build_id =
+      build_host
+      |> Map.get(:id)
+      |> String.slice(0, 12)
+    IO.puts "Build host is #{build_id}"
 
     File.open!(Path.join([location, "config", "deploy.exs"]), [:write], fn file ->
       IO.write(file, """

--- a/test/phoenix_digest_test.exs
+++ b/test/phoenix_digest_test.exs
@@ -1,4 +1,5 @@
 defmodule BootlegPhoenix.PhoenixDigestTest do
+  require Logger
   alias BootlegPhoenix.Fixtures
   use BootlegPhoenix.FunctionalCase
 
@@ -8,7 +9,7 @@ defmodule BootlegPhoenix.PhoenixDigestTest do
     }
   end
 
-  @tag boot: 2, timeout: 360_000
+  @tag boot: 2, verbose: true, timeout: 360_000
   test "phoenix_digest generates the digest during compile", %{app_location: location, hosts: hosts} do
     shell_env = [
       {"BOOTLEG_PHOENIX_PATH", File.cwd!},
@@ -16,11 +17,9 @@ defmodule BootlegPhoenix.PhoenixDigestTest do
     ]
     build_host = List.first(hosts)
     app_hosts = hosts -- [build_host]
-    build_id =
-      build_host
-      |> Map.get(:id)
-      |> String.slice(0, 12)
-    IO.puts "Build host is #{build_id}"
+
+    Logger.info "build host is #{container_id(build_host)}"
+    Logger.info "app hosts are #{container_id(app_hosts)}"
 
     File.open!(Path.join([location, "config", "deploy.exs"]), [:write], fn file ->
       IO.write(file, """
@@ -38,10 +37,21 @@ defmodule BootlegPhoenix.PhoenixDigestTest do
     end)
 
     Enum.each(["deps.get", "bootleg.build", "bootleg.deploy", "bootleg.start"], fn cmd ->
+      Logger.info "-> running mix #{cmd}.."
       assert {out, 0} = System.cmd("mix", [cmd], [env: shell_env, cd: location])
       if cmd == "bootleg.build" do
         assert String.match?(out, ~r/Phoenix asset digest generated/)
       end
     end)
+  end
+
+  defp container_id(hosts) when is_list(hosts) do
+    hosts
+    |> Enum.map(&container_id/1)
+    |> Enum.join(", ")
+  end
+
+  defp container_id(%{id: id}) do
+    String.slice(id, 0, 12)
   end
 end

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM bitwalker/alpine-elixir:latest
 # Autogenerate missing host keys.
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
-RUN apk add --update --no-cache openssh sudo perl-utils git
+RUN apk add --update --no-cache openssh sudo perl-utils git nodejs-npm
 RUN ssh-keygen -A
 RUN printf "PermitUserEnvironment yes\n" >> /etc/ssh/sshd_config
 

--- a/test/support/functional_case.ex
+++ b/test/support/functional_case.ex
@@ -26,7 +26,8 @@ defmodule BootlegPhoenix.FunctionalCase do
     hosts = Enum.map(1..count, fn _ -> init(boot(conf)) end)
 
     if Map.get(tags, :verbose, System.get_env("TEST_VERBOSE")) do
-      Logger.info("started docker hosts: #{inspect hosts, pretty: true}")
+      Logger.configure(level: :debug)
+      Logger.debug("started docker hosts: #{inspect hosts, pretty: true}")
     end
 
     unless Map.get(tags, :leave_vm, System.get_env("TEST_LEAVE_CONTAINER")) do


### PR DESCRIPTION
Corrects the current behavior of digest task not succeeding due to an assumed `dev` environment.

The tests didn't catch this because the task's commands include bash tests which return success even if the needed binaries aren't available. Those bash tests were originally used because Bootleg was deploying non-Phoenix applications.

A failure of a necessary Phoenix asset build step should result in an error that bubbles up to the end-user.