### PR TITLE
Set MIX_ENV during Phoenix digest

### DIFF
--- a/lib/bootleg/tasks/phoenix_digest.ex
+++ b/lib/bootleg/tasks/phoenix_digest.ex
@@ -1,13 +1,14 @@
 defmodule Bootleg.Tasks.PhoenixDigest do
-  @moduledoc "Installs needed depedencies and calls `mix phoenix.digest`."
-  alias Bootleg.UI
+  @moduledoc "Installs dependencies and calls `mix phoenix.digest`."
+  alias Bootleg.{Config, UI}
 
   use Bootleg.Task do
     task :phoenix_digest do
+      mix_env = Config.get_config(:mix_env, "prod")
       remote :build do
         "[ -f package.json ] && npm install || true"
         "[ -f brunch-config.js ] && [ -d node_modules ] && ./node_modules/brunch/bin/brunch b -p || true"
-        "[ -d deps/phoenix ] && mix phoenix.digest || true"
+        "[ -d deps/phoenix ] && MIX_ENV=#{mix_env} mix phoenix.digest || true"
       end
       UI.info "Phoenix asset digest generated"
     end


### PR DESCRIPTION
Corrects the current behavior of digest task not succeeding due to an assumed dev environment.