### PR TITLE
Raise errors when building assets

### DIFF
--- a/lib/bootleg/tasks/phoenix_digest.ex
+++ b/lib/bootleg/tasks/phoenix_digest.ex
@@ -1,13 +1,15 @@
 defmodule Bootleg.Tasks.PhoenixDigest do
-  @moduledoc "Installs needed depedencies and calls `mix phoenix.digest`."
-  alias Bootleg.UI
+  @moduledoc "Installs dependencies and calls `mix phoenix.digest`."
+
+  alias Bootleg.{Config, UI}
 
   use Bootleg.Task do
     task :phoenix_digest do
+      mix_env = Config.get_config(:mix_env, "prod")
       remote :build do
-        "[ -f package.json ] && npm install || true"
-        "[ -f brunch-config.js ] && [ -d node_modules ] && ./node_modules/brunch/bin/brunch b -p || true"
-        "[ -d deps/phoenix ] && mix phoenix.digest || true"
+        "npm install"
+        "./node_modules/brunch/bin/brunch build --production"
+        "MIX_ENV=#{mix_env} mix phoenix.digest"
       end
       UI.info "Phoenix asset digest generated"
     end

--- a/test/fixtures/drunkin_phoenix/brunch-config.js
+++ b/test/fixtures/drunkin_phoenix/brunch-config.js
@@ -1,0 +1,69 @@
+exports.config = {
+  // See http://brunch.io/#documentation for docs.
+  files: {
+    javascripts: {
+      joinTo: "js/app.js"
+
+      // To use a separate vendor.js bundle, specify two files path
+      // http://brunch.io/docs/config#-files-
+      // joinTo: {
+      //  "js/app.js": /^(web\/static\/js)/,
+      //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/
+      // }
+      //
+      // To change the order of concatenation of files, explicitly mention here
+      // order: {
+      //   before: [
+      //     "web/static/vendor/js/jquery-2.1.1.js",
+      //     "web/static/vendor/js/bootstrap.min.js"
+      //   ]
+      // }
+    },
+    stylesheets: {
+      joinTo: "css/app.css",
+      order: {
+        after: ["web/static/css/app.css"] // concat app.css last
+      }
+    },
+    templates: {
+      joinTo: "js/app.js"
+    }
+  },
+
+  conventions: {
+    // This option sets where we should place non-css and non-js assets in.
+    // By default, we set this to "/web/static/assets". Files in this directory
+    // will be copied to `paths.public`, which is "priv/static" by default.
+    assets: /^(web\/static\/assets)/
+  },
+
+  // Phoenix paths configuration
+  paths: {
+    // Dependencies and current project directories to watch
+    watched: [
+      "web/static",
+      "test/static"
+    ],
+
+    // Where to compile files to
+    public: "priv/static"
+  },
+
+  // Configure your plugins
+  plugins: {
+    babel: {
+      // Do not use ES6 compiler in vendor code
+      ignore: [/web\/static\/vendor/]
+    }
+  },
+
+  modules: {
+    autoRequire: {
+      "js/app.js": ["web/static/js/app"]
+    }
+  },
+
+  npm: {
+    enabled: true
+  }
+};

--- a/test/fixtures/drunkin_phoenix/mix.exs
+++ b/test/fixtures/drunkin_phoenix/mix.exs
@@ -33,6 +33,7 @@ defmodule DrunkinPhoenix.Mixfile do
       {:phoenix_pubsub, "~> 1.0"},
       {:cowboy, "~> 1.0"},
       {:distillery, "~> 1.4", runtime: false},
+      {:bootleg, "~> 0.2.0", runtime: false, override: true},
       {:bootleg_phoenix, ">= 0.0.0", path: System.get_env("BOOTLEG_PHOENIX_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/drunkin_phoenix/package.json
+++ b/test/fixtures/drunkin_phoenix/package.json
@@ -1,0 +1,19 @@
+{
+  "repository": {},
+  "license": "MIT",
+  "scripts": {
+    "deploy": "brunch build --production",
+    "watch": "brunch watch --stdin"
+  },
+  "dependencies": {
+    "phoenix": "file:deps/phoenix"
+  },
+  "devDependencies": {
+    "babel-brunch": "~6.0.0",
+    "brunch": "2.7.4",
+    "clean-css-brunch": "~2.0.0",
+    "css-brunch": "~2.0.0",
+    "javascript-brunch": "~2.0.0",
+    "uglify-js-brunch": "~2.0.1"
+  }
+}

--- a/test/support/docker/Dockerfile
+++ b/test/support/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM bitwalker/alpine-elixir:latest
 # Autogenerate missing host keys.
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
-RUN apk add --update --no-cache openssh sudo perl-utils git
+RUN apk add --update --no-cache openssh sudo perl-utils git nodejs-npm
 RUN ssh-keygen -A
 RUN printf "PermitUserEnvironment yes\n" >> /etc/ssh/sshd_config
 


### PR DESCRIPTION
Errors are currently ignored when building assets, so build output is unreliable. The task's commands included bash tests which return success even if the needed binaries aren't available. Those bash tests were originally used because Bootleg was deploying non-Phoenix applications.

A failure of a necessary Phoenix asset build step should result in an error that bubbles up to the end-user. This may be handled more elegantly in the future but for now we can assume a standard Phoenix installation.